### PR TITLE
Make multi-GPU runs stable (grid clamp, per-device constants)

### DIFF
--- a/src/address.h
+++ b/src/address.h
@@ -6,13 +6,17 @@
 #include "math.h"
 
 
-__global__ void __launch_bounds__(BLOCK_SIZE) gpu_address_init(CurvePoint* block_offsets, CurvePoint* offsets) {
+__global__ void __launch_bounds__(BLOCK_SIZE) gpu_address_init(CurvePoint* block_offsets, CurvePoint* offsets, uint32_t grid_size) {
     bool b = __isGlobal(block_offsets);
     __builtin_assume(b);
     bool b2 = __isGlobal(offsets);
     __builtin_assume(b2);
 
     uint64_t thread_id = (uint64_t)threadIdx.x + (uint64_t)blockIdx.x * (uint64_t)BLOCK_SIZE;
+
+    if (thread_id >= grid_size) {
+        return;
+    }
 
     _uint256 z[BLOCK_SIZE];
     z[0] = sub_256_mod_p(block_offsets[thread_id].x, thread_offsets[0].x);


### PR DESCRIPTION
### Problem

Running the original code across multiple GPUs crashed (segfault) because it assumed a single device. Per‑GPU state was shared, grid dimensions could drop to zero, and kernels indexed past their buffers.

### Fix

- Clamp each device’s GRID_SIZE to at least 1, and pass its actual work size into kernels so partial blocks don’t read past block_offsets.
- Every worker thread now sets its own device and copies the prefix/suffix constants (cudaMemcpyToSymbol after cudaSetDevice), so each GPU sees the right filters.
- Fixed hex parsing buffers (char[3]/char[9] with null terminators) and removed a duplicate host allocation to avoid random crashes.
- Made the host control loop robust: store per‑GPU speeds in a vector, validate device_index when queuing messages, and clamp kernel launches so out-of-range threads bail early.

### Result

After these fixes the miner now runs cleanly on multi-GPU rigs; on Vast.ai it pushed 4× RTX 5090s to ≈19,500 Mkeys/s (≈4,900 Mkeys/s per card) with no crashes.